### PR TITLE
Update the new name from `iOS Essentials Program` to `iOS Ready Program`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repo contains all the downloadable materials and projects associated with t
 
 ### [Networking & Concurrency in SwiftUI Course](https://www.kodeco.com/ios/paths/networking-concurrency-swiftui)
 
-- This course is part of [iOS Essentials Program](https://www.kodeco.com/ios/programs/ios-essentials), which you can take as either on-demand or live bootcamp from [Kodeco](https://www.kodeco.com).
+- This course is part of [iOS Ready Program](https://www.kodeco.com/ios/programs/ios-ready), which you can take as either on-demand or live bootcamp from [Kodeco](https://www.kodeco.com).
 
 
 ---


### PR DESCRIPTION
Update the new name from `iOS Essentials Program` to `iOS Ready Program`.
